### PR TITLE
TBRouter updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ public protocol TBRoutable: class {
   static func loadController(with data: Any?, for route: String) -> UIViewController?
 }
 ```
-Example:
+
+The TBRoutable protocol has a default implementation that just returns the designated initializer. If you need more control on initialization you can override it.
+
 ```swift
 class HomeViewController: UIViewController, TBRoutable {
   public static func loadController(with data: Any?, for route: String) -> UIViewController? {
@@ -51,10 +53,17 @@ class HomeViewController: UIViewController, TBRoutable {
 
 Routes can be added manually:
 
+
+
+
 ```swift
-TBRouter.addRoute("home", routableClass: HomeViewController.self)
+extension TBRouter.Route {
+  static let home = TBRouter.Route("home")
+}
+
+TBRouter.addRoute(.home, routableClass: HomeViewController.self)
 ```
-Or with local or remote router file (JSON):
+Or from a local or a remote routes file (JSON):
 *Routes.json*
 ```json
 {
@@ -72,14 +81,14 @@ if let url = Bundle.main.url(forResource: "Routes", withExtension: "json") {
 
 To perform a route just call `x_performRoute` from `UIViewController`:
 ```swift
-x_performRoute("home", presentationType: .push)
+x_performRoute(.home, presentationType: .push)
 //or
-x_performRoute("home", presentationType: .modal, data: someData, animated: true)
+x_performRoute(.home, presentationType: .modal, data: someData, animated: true)
 ```
 
 Or just get the route's controller and perform a presentation programmatically:
 ```swift
-let homeController = TBRouter.route("home", with: someData)
+let homeController = TBRouter.route(.home, with: someData)
 ```
 
 ## Container

--- a/ToolBox/Classes/SharedUI/Router/TBRoutable.swift
+++ b/ToolBox/Classes/SharedUI/Router/TBRoutable.swift
@@ -13,4 +13,10 @@ public protocol TBRoutable: class {
   
 }
 
+public extension TBRoutable where Self: UIViewController {
+  
+  static func loadController(with data: Any?, for route: String) -> UIViewController? {
+    return self.init()
+  }
 
+}

--- a/ToolBox/Classes/SharedUI/Router/TBRouter.swift
+++ b/ToolBox/Classes/SharedUI/Router/TBRouter.swift
@@ -8,25 +8,21 @@
 import Foundation
 
 public struct TBRouter {
-  
-  public static func addRoute(_ route: String, routableClass: TBRoutable.Type) {
-    TBContainer.add(routableClass, for: route)
+
+  public static func addRoute(_ route: Route, routableClass: TBRoutable.Type) {
+    TBContainer.add(routableClass, for: route.rawValue)
   }
   
-  public static func remove(_ route: String) {
-    TBContainer<TBRoutable.Type>.removeValue(for: route)
+  public static func remove(_ route: Route) {
+    TBContainer<TBRoutable.Type>.removeValue(for: route.rawValue)
   }
   
-  public static func route(_ route: String, with data: Any?) -> UIViewController? {
-    let routable: TBRoutable.Type? = TBContainer.getValue(for: route)
-    return routable?.loadController(with: data, for: route)
+  public static func route(_ route: Route, with data: Any?) -> UIViewController? {
+    let routable: TBRoutable.Type? = TBContainer.getValue(for: route.rawValue)
+    return routable?.loadController(with: data, for: route.rawValue)
   }
   
-  public static func route(route: TBRouter.Route, with data: Any?) -> UIViewController? {
-    return self.route(route.rawValue, with: data)
-  }
-  
-  public static func remove(route: TBRouter.Route) {
+  public static func remove(route: Route) {
     TBContainer<TBRoutable.Type>.removeValue(for: route.rawValue)
   }
   
@@ -57,16 +53,16 @@ extension TBRouter {
   fileprivate static func addRoutes(from data: [String: [String: Any]]?) -> Bool {
     guard let routesInfos = data else { return false }
     
-    for (route, infos) in routesInfos {
+    for (routeRawValue, infos) in routesInfos {
       guard let className = infos["class"] else {
         return false
       }
       let bundleName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? ""
       if let routableClass = NSClassFromString("\(bundleName).\(className)") as? TBRoutable.Type {
-        TBRouter.addRoute(route, routableClass: routableClass)
+        TBRouter.addRoute(Route(routeRawValue), routableClass: routableClass)
       }
       else if let routableClass = NSClassFromString("\(className)") as? TBRoutable.Type {
-        TBRouter.addRoute(route, routableClass: routableClass)
+        TBRouter.addRoute(Route(routeRawValue), routableClass: routableClass)
       }
       else {
         tbPrint("[TBROUTER] Fail to add route \(route) with infos: \(infos)", category: .ui)

--- a/ToolBox/Classes/SharedUI/Router/UIViewController+Router.swift
+++ b/ToolBox/Classes/SharedUI/Router/UIViewController+Router.swift
@@ -11,19 +11,13 @@ import Foundation
 public extension UIViewController {
   
   @discardableResult
-  public func x_performRoute(_ route: String, presentationType: TBPresentationType, data: Any? = nil, animated: Bool = true) -> Bool {
-    let routableControllerType: TBRoutable.Type? = TBContainer.getValue(for: route)
-    guard let controller = routableControllerType?.loadController(with: data, for: route) else {
+  public func x_performRoute(_ route: TBRouter.Route, presentationType: TBPresentationType, data: Any? = nil, animated: Bool = true) -> Bool {
+    let routableControllerType: TBRoutable.Type? = TBContainer.getValue(for: route.rawValue)
+    guard let controller = routableControllerType?.loadController(with: data, for: route.rawValue) else {
         return false
     }
     self.x_present(controller, type: presentationType, data: data, animated: animated)
     return true
   }
-  
-  @discardableResult
-  public func x_performRoute(route: TBRouter.Route, presentationType: TBPresentationType, data: Any? = nil, animated: Bool = true) -> Bool {
-    return x_performRoute(route.rawValue, presentationType: presentationType, data: data, animated: animated)
-  }
-  
   
 }


### PR DESCRIPTION
1) Added a default implementation to the `TBRouterProtocol`. So for basic usage you can conform  in a easier and quicker way.

2) Made compulsory the use of TBRouter.Route to define routes. It's not possible anymore to refer to a route with a literal string. Please double check this commit because maybe there were deeper reasons to keep strings literals as routes.